### PR TITLE
Fix container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ LABEL org.opencontainers.image.title="secureCodeBox scanner-infrastructure-sslyz
     org.opencontainers.image.revision=$COMMIT_ID \
     org.opencontainers.image.created=$BUILD_DATE
 
-ENTRYPOINT [ "npm", "start" ]
+ENTRYPOINT [ "node", "index.js" ]


### PR DESCRIPTION
Container currently doesn't start correctly as the default node installation doesn't come with npm anymore, this was already partially tackled in #15 but I forgot to properly fix the `CMD` of the container.

The error being thrown is:

```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"npm\": executable file not found in $PATH": unknown.
```
