### PR TITLE
Show process init logs only when DEBUG is enabled

### DIFF
--- a/lib/node-sslyze/index.js
+++ b/lib/node-sslyze/index.js
@@ -101,9 +101,11 @@ class SSLyzeScan extends EventEmitter {
      */
     initChild() {
         this.startTimer();
-        console.log(
-            'Initializing child: ' + sslyze.pythonLocation + ' with arguments ' + this.command
-        );
+        if (process.env['DEBUG']) {
+            console.log(
+                'Initializing child: ' + sslyze.pythonLocation + ' with arguments ' + this.command
+            );
+        }
         this.child = spawn(sslyze.pythonLocation, this.command);
         process.on('SIGINT', this.killChild);
         process.on('uncaughtException', this.killChild);


### PR DESCRIPTION
Currently for every health check call one log message is written, which clutters the log without providing a helpful information.